### PR TITLE
readList() now returns a bytearray

### DIFF
--- a/mcp.py
+++ b/mcp.py
@@ -68,7 +68,7 @@ class MCP():
 
     def readList(self, register, length):
         """Introduced to match the readList implementation of the Adafruit I2C _device member"""
-        return self.i2c.readfrom_mem(self.address, register, length)
+        return bytearray(self.i2c.readfrom_mem(self.address, register, length))
 
     def setup(self, pin, value):
         """Set the input or output mode for a specified pin.  Mode should be


### PR DESCRIPTION
output_pins() expects self.gpio to be a bytearray but read_gpio() was changing it's type by using the return of readList() directly

Fixes issue #2